### PR TITLE
optional distance

### DIFF
--- a/LiftLog.xcodeproj/project.pbxproj
+++ b/LiftLog.xcodeproj/project.pbxproj
@@ -462,6 +462,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"LiftLog/Preview Content\"";
+				DEVELOPMENT_TEAM = 6K47RF3TMB;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -490,6 +491,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"LiftLog/Preview Content\"";
+				DEVELOPMENT_TEAM = 6K47RF3TMB;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;

--- a/Progress+CoreDataProperties.swift
+++ b/Progress+CoreDataProperties.swift
@@ -20,6 +20,15 @@ extension Progress {
     @NSManaged public var weight: Int64
     @NSManaged public var reps: Int64
     @NSManaged public var sets: Int64
+    public var distanceOptional: Int64? {
+        get {
+            // Return nil if distance is a default value (e.g., 0) or use an optional Int64 directly
+            return distance == 0 ? nil : distance
+        }
+        set {
+            distance = newValue ?? 0 // Store 0 if nil
+        }
+    }
     @NSManaged public var distance: Int64
     @NSManaged public var exercise: Exercise?
     @NSManaged public var workout: Workouts?


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 043fd41beb5d7e1f90239dc379c4b20f8366f806  | 
|--------|--------|

### Summary:
Added `distanceOptional` property to `Progress` class for optional handling of `distance` and updated Xcode project with `DEVELOPMENT_TEAM`.

**Key points**:
- Added `distanceOptional` property in `Progress+CoreDataProperties.swift`.
- `distanceOptional` returns `nil` if `distance` is 0, otherwise returns `distance`.
- `distanceOptional` sets `distance` to 0 if `nil` is assigned.
- Updated `LiftLog.xcodeproj/project.pbxproj` to include `DEVELOPMENT_TEAM`.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->